### PR TITLE
Ds4 dongle

### DIFF
--- a/JoyShockLibrary/InputHelpers.cpp
+++ b/JoyShockLibrary/InputHelpers.cpp
@@ -30,8 +30,8 @@ bool handle_input(JoyShock *jc, uint8_t *packet, int len, bool &hasIMU) {
 		}
 		else {
 			isValid = packet[0] == 0x01;
-			if (isValid) // ignore packets from Dongle with no connected controller
-				if ((packet[31] & 0x04) == 0x04) return false;
+			if (isValid && (packet[31] & 0x04) == 0x04)
+				return false; // ignore packets from Dongle with no connected controller
 		}
 		if (isValid) {
 			// Gyroscope:

--- a/JoyShockLibrary/InputHelpers.cpp
+++ b/JoyShockLibrary/InputHelpers.cpp
@@ -33,8 +33,6 @@ bool handle_input(JoyShock *jc, uint8_t *packet, int len, bool &hasIMU) {
 			if (isValid) // ignore packets from Dongle with no connected controller
 				if ((packet[31] & 0x04) == 0x04) return false;
 		}
-
-
 		if (isValid) {
 			// Gyroscope:
 			// Gyroscope data is relative (degrees/s)

--- a/JoyShockLibrary/InputHelpers.cpp
+++ b/JoyShockLibrary/InputHelpers.cpp
@@ -30,7 +30,11 @@ bool handle_input(JoyShock *jc, uint8_t *packet, int len, bool &hasIMU) {
 		}
 		else {
 			isValid = packet[0] == 0x01;
+			if (isValid) // ignore packets from Dongle with no connected controller
+				if ((packet[31] & 0x04) == 0x04) return false;
 		}
+
+
 		if (isValid) {
 			// Gyroscope:
 			// Gyroscope data is relative (degrees/s)

--- a/JoyShockLibrary/JoyShock.cpp
+++ b/JoyShockLibrary/JoyShock.cpp
@@ -22,6 +22,7 @@
 #define DS4_VENDOR 0x054C
 #define DS4_USB 0x05C4
 #define DS4_USB_V2 0x09CC
+#define DS4_USB_DONGLE 0x0BA0
 #define DS4_BT 0x081F
 
 // Joycon and Pro conroller stuff is mostly from
@@ -305,6 +306,7 @@ public:
 
 		if (dev->product_id == DS4_BT ||
 			dev->product_id == DS4_USB ||
+			dev->product_id == DS4_USB_DONGLE ||
 			dev->product_id == DS4_USB_V2) {
 			this->name = std::string("DualShock 4");
 			this->left_right = 3; // left and right?

--- a/JoyShockLibrary/JoyShockLibrary.cpp
+++ b/JoyShockLibrary/JoyShockLibrary.cpp
@@ -224,6 +224,7 @@ int JslConnectDevices()
 			printf("DS4\n");
 			if (cur_dev->product_id == DS4_USB ||
 				cur_dev->product_id == DS4_USB_V2 ||
+				cur_dev->product_id == DS4_USB_DONGLE ||
 				cur_dev->product_id == DS4_BT) {
 				JoyShock* jc = new JoyShock(cur_dev, GetUniqueHandle());
 				_joyshocks.emplace(jc->intHandle, jc);


### PR DESCRIPTION
Implemented basic DS4 dongle support.
The dongle acts like a USB connection aside from the addition of a single bit in the report. This bit is high when no controller is attached and 0 for all standard controller connections making logic checking this bit backwards compatible with non-dongle connections.
Note that when the dongle has no controller attached it will return the same report on repeat. This report, with no delta time between identical motions, will cause JSM's logic to divide-by-zero if passed along. For this reason all reports from a dongle in the disconnected state are considered invalid in this pull.