### PR TITLE
Expand on touch callback to report relative movement in raw unit.

### DIFF
--- a/JoyShockLibrary/JoyShock.cpp
+++ b/JoyShockLibrary/JoyShock.cpp
@@ -9,6 +9,7 @@
 #include <atomic>
 #include "tools.cpp"
 #include <cstring>
+#include <array> // same as [] but with vector accessors
 
 #ifdef __GNUC__
 #define _wcsdup wcsdup
@@ -76,8 +77,8 @@ public:
 	IMU_STATE imu_state = {};
 	IMU_STATE last_imu_state = {};
 
-	TOUCH_STATE touch_state = {};
-	TOUCH_STATE last_touch_state = {};
+	std::array<TOUCH_POINT, 2> touch_point; // Send point to the callbacks
+	std::array<TOUCH_STATE, 2> prev_touch_state; // Hold the prev state info
 
 	Motion motion;
 

--- a/JoyShockLibrary/JoyShock.cpp
+++ b/JoyShockLibrary/JoyShock.cpp
@@ -1479,7 +1479,7 @@ public:
 			res = hid_write(handle, buf, sizeof(*hdr) + sizeof(*pkt));
 
 			res = hid_read_timeout(handle, buf, sizeof(buf), 1000);
-			if (res == 0)
+			if (res == 0 || res == -1)
 			{
 				return false;
 			}

--- a/JoyShockLibrary/JoyShockLibrary.h
+++ b/JoyShockLibrary/JoyShockLibrary.h
@@ -108,15 +108,19 @@ typedef struct MOTION_STATE {
 	float gravZ;
 } MOTION_STATE;
 
+typedef struct TOUCH_POINT {
+	float posX = -1.f;
+	float posY = -1.f;
+	short movX = 0;
+	short movY = 0;
+	inline bool isDown() { return posX >= 0.f && posX <= 1.f && posY >= 0.f && posY <= 1.f; }
+} TOUCH_POINT;
+
 typedef struct TOUCH_STATE {
-	int t0Id;
-	int t1Id;
-	bool t0Down;
-	bool t1Down;
-	float t0X;
-	float t0Y;
-	float t1X;
-	float t1Y;
+	int tId = -1;
+	bool tDown = false;
+	int tX = 0;
+	int tY = 0;
 } TOUCH_STATE;
 
 extern "C" JOY_SHOCK_API int JslConnectDevices();
@@ -149,7 +153,7 @@ extern "C" JOY_SHOCK_API void JslDisconnectAndDisposeAll();
 extern "C" JOY_SHOCK_API JOY_SHOCK_STATE JslGetSimpleState(int deviceId);
 extern "C" JOY_SHOCK_API IMU_STATE JslGetIMUState(int deviceId);
 extern "C" JOY_SHOCK_API MOTION_STATE JslGetMotionState(int deviceId);
-extern "C" JOY_SHOCK_API TOUCH_STATE JslGetTouchState(int deviceId);
+extern "C" JOY_SHOCK_API TOUCH_POINT JslGetTouchPoint(int deviceId, int touchIndex);
 
 extern "C" JOY_SHOCK_API int JslGetButtons(int deviceId);
 
@@ -173,13 +177,6 @@ extern "C" JOY_SHOCK_API float JslGetAccelX(int deviceId);
 extern "C" JOY_SHOCK_API float JslGetAccelY(int deviceId);
 extern "C" JOY_SHOCK_API float JslGetAccelZ(int deviceId);
 
-// get touchpad
-extern "C" JOY_SHOCK_API int JslGetTouchId(int deviceId, bool secondTouch = false);
-extern "C" JOY_SHOCK_API bool JslGetTouchDown(int deviceId, bool secondTouch = false);
-
-extern "C" JOY_SHOCK_API float JslGetTouchX(int deviceId, bool secondTouch = false);
-extern "C" JOY_SHOCK_API float JslGetTouchY(int deviceId, bool secondTouch = false);
-
 // analog parameters have different resolutions depending on device
 extern "C" JOY_SHOCK_API float JslGetStickStep(int deviceId);
 extern "C" JOY_SHOCK_API float JslGetTriggerStep(int deviceId);
@@ -195,7 +192,7 @@ extern "C" JOY_SHOCK_API void JslSetCalibrationOffset(int deviceId, float xOffse
 // this function will get called for each input event from each controller
 extern "C" JOY_SHOCK_API void JslSetCallback(void(*callback)(int, JOY_SHOCK_STATE, JOY_SHOCK_STATE, IMU_STATE, IMU_STATE, float));
 // this function will get called for each input event, even if touch data didn't update
-extern "C" JOY_SHOCK_API void JslSetTouchCallback(void(*callback)(int, TOUCH_STATE, TOUCH_STATE, float));
+extern "C" JOY_SHOCK_API void JslSetTouchCallback(void(*callback)(int, TOUCH_POINT, TOUCH_POINT, float));
 
 // what kind of controller is this?
 extern "C" JOY_SHOCK_API int JslGetControllerType(int deviceId);

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ The latest version of JoyShockLibrary can always be found [here](https://github.
 * **float accelX, accelY, accelZ** - local acceleration after accounting for and removing the effect of gravity.
 * **float gravX, gravY, gravZ** - local gravity direction.
 
+**struct TOUCH_POINT** - The TOUCH_POINT reports a single touch event on the device touch sensitive sensor, such as the DS4 touchpad.
+* **float posX, posY** - The absolute position of the touch point as a percentage.
+* **short movX, movY** - Relative movement, or difference of raw positions with the previous report.
+
 ### Functions
 
 All these functions *should* be thread-safe, and none of them should cause any harm if given the wrong handle. If they do, please report this to me as an isuse.
@@ -73,7 +77,7 @@ All these functions *should* be thread-safe, and none of them should cause any h
 
 **MOTION\_STATE JslGetMotionState(int deviceId)** - Get the latest motion state for the controller with the given id.
 
-**TOUCH\_STATE JslGetTouchState(int deviceId)** - Get the latest touchpad state for the controller with the given id. Only DualShock 4s support this.
+**TOUCH\_POINT JslGetTouchPoint(int deviceId, int touchIndex)** - Get the latest report for touch point of given index for the controller with the given id. Only DualShock 4s support this.
 
 **int JslGetButtons(int deviceId)** - Get the latest button state for the controller with the given id. If you want more than just the buttons, it's more efficient to use JslGetSimpleState.
 
@@ -84,12 +88,6 @@ All these functions *should* be thread-safe, and none of them should cause any h
 **float JslGetGyroX/JslGetGyroY/JslGetGyroZ(int deviceId)** - Get the latest angular velocity for a given gyroscope axis. If you want more than just a single gyroscope axis velocity, it's more efficient to use JslGetIMUState.
 
 **float JslGetAccelX/JslGetAccelY/JslGetAccelZ(int deviceId)** - Get the latest acceleration for a given axis. If you want more than just a accelerometer axis, it's more efficient to use JslGetIMUState.
-
-**int JslGetTouchId(int deviceId, bool secondTouch=false)** - Get the last touch's id, which is a value in range of 0-127 that automaticaly increments whenever a new touch appears, for the controller with the given id. Only DualShock 4s support this. If you want more than just a touch's id, it's more efficient to use JslGetTouchState.
-
-**bool JslGetTouchDown(int deviceId, bool secondTouch=false)** - Get the latest state of the touch being present on a touchpad for the controller with the given id. Only DualShock 4s support this. If you want more than just a presence of touch, it's more efficient to use JslGetTouchState.
-
-**float JslGetTouchX/JslGetTouchY(int deviceId, bool secondTouch=false)** - Get the latest touch state for the controller with the given id. Only DualShock 4s support this. If you want more than just a single touch axis, it's more efficient to use JslGetTouchState.
 
 **float JslGetStickStep(int deviceId)** - Different devices use different size data types and different ranges on those data types when reporting stick axes. For some calculations, it may be important to know the limits of the current device and work around them in different ways. This gives the smallest step size between two values for the given device's analog sticks.
 
@@ -111,7 +109,7 @@ All these functions *should* be thread-safe, and none of them should cause any h
 
 **void JslSetCallback(void(\*callback)(int, JOY\_SHOCK\_STATE, JOY\_SHOCK\_STATE, IMU\_STATE, IMU\_STATE, float))** - Set a callback function by which JoyShockLibrary can report the current state for each device. This callback will be given the *deviceId* for the reporting device, its current button + trigger + stick state, its previous button + trigger + stick state, its current accelerometer + gyro state, its previous accelerometer + gyro state, and the amount of time since the last report for this device (in seconds).
 
-**void JslSetTouchCallback(void(\*callback)(int, TOUCH\_STATE, TOUCH\_STATE, float))** - Set a callback function by which JoyShockLibrary can report the current touchpad state for each device. Only DualShock 4s will use this. This callback will be given the *deviceId* for the reporting device, its current and previous touchpad states, and the amount of time since the last report for this device (in seconds).
+**void JslSetTouchCallback(void(\*callback)(int, TOUCH\_POINT, TOUCH\_POINT, float))** - Set a callback function by which JoyShockLibrary can report the current touchpad state for each device. Only DualShock 4s will use this. This callback will be given the *deviceId* for the reporting device, its two touch points, and the amount of time since the last report for this device (in seconds).
 
 **int JslGetControllerType(int deviceId)** - What type of controller is this device?
   1. Left Joy-Con


### PR DESCRIPTION
From Discord:

Currently, I get 2 touch points and their absolute location in percentage. This works great for buttons, but if I want to do a cursor mode, I'm going to need the "raw" movement value, not the percentage. Biggest reason for this need is so not to warp the trackpad space since it is not square. Now, to make it device agnostic (with the foresight of steam controller support for example) percentage is proper, so I was thinking in addition to what it currently holds, the structure could also contain the raw displacement. That would make the information independent from the pad's resolution or shape.

Other line of thought was whether we would want the callback to scale better with the number of touchpoints. DS4 and SC really have 2, but could/should we plan to support a scalable amount? Something like VR controllers would support a touchpoint on every finger. This implementation has both touch point as individual parameters.