### PR TITLE
Fix memory leak disconnecting controllers.

### DIFF
--- a/JoyShockLibrary/JoyShockLibrary.cpp
+++ b/JoyShockLibrary/JoyShockLibrary.cpp
@@ -354,6 +354,7 @@ void JslDisconnectAndDisposeAll()
 		// threads for polling
 		jc->cancel_thread = true;
 		jc->thread->join();
+		delete jc->thread;
 		if (jc->controller_type == ControllerType::s_ds4) {
 			if (jc->is_usb) {
 				jc->deinit_ds4_usb();


### PR DESCRIPTION
JoyShock::thread should probably just be a std::thread rather than a pointer to one, and use std::move on thread creation. Let me know if you'd like me to submit that change.
For now though, this simply addresses the memory leak that happens for each disconnected JoyShock.