### PR TITLE
Bugfix in the switch case values of touchpad dimensions

### DIFF
--- a/JoyShockLibrary/JoyShockLibrary.cpp
+++ b/JoyShockLibrary/JoyShockLibrary.cpp
@@ -458,8 +458,8 @@ bool JslGetTouchpadDimension(int deviceId, int &sizeX, int &sizeY)
 	{
 		switch (jc->controller_type)
 		{
-		case JS_TYPE_DS4:
-		case JS_TYPE_DS:
+		case ControllerType::s_ds4:
+		case ControllerType::s_ds:
 			sizeX = 1920;
 			sizeY = 943;
 			break;

--- a/scripts/generate_win64_vs_solution.bat
+++ b/scripts/generate_win64_vs_solution.bat
@@ -7,7 +7,7 @@ for %%a in (.) do set projectDir=%%~na
 cd ..
 mkdir build-jsl-win64
 cd build-jsl-win64
-cmake ../%projectDir% -G "Visual Studio 16 2019" -A x64 -DBUILD_SHARED_LIBS=1
+cmake ../%projectDir% -A x64 -DBUILD_SHARED_LIBS=1
 
 echo Open the generated Visual Studio solution located at: %cd%\JoyShockLibrary.sln
 


### PR DESCRIPTION
I got jerbaited when I set the values of the switch case: I expected the JSL header types but there's an inner enum being used instead. My bad. :(