### PR TITLE
Fixed compilation under MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.12)
 
 project ("JoyShockLibrary" CXX)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 
 include (cmake/LinuxConfig.cmake)
 include (cmake/WindowsConfig.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required (VERSION 3.12)
 
 project ("JoyShockLibrary" CXX)
 
+set(CMAKE_CXX_STANDARD 20)
+
 include (cmake/LinuxConfig.cmake)
 include (cmake/WindowsConfig.cmake)
 


### PR DESCRIPTION
Usage of std::clamp requires c++17 under MSVC