### PR TITLE
Make read-lock for callbacks exception-safe with RAII shared_lock wrapper

### DIFF
--- a/JoyShockLibrary/JoyShockLibrary.cpp
+++ b/JoyShockLibrary/JoyShockLibrary.cpp
@@ -112,7 +112,7 @@ void pollIndividualLoop(JoyShock *jc) {
 			if (handle_input(jc, buf, 64, hasIMU)) { // but the user won't necessarily have a callback at all, so we'll skip the lock altogether in that case
 				if (_pollCallback != nullptr || _pollTouchCallback != nullptr)
 				{
-					_callbackLock.lock_shared();
+					std::shared_lock<std::shared_timed_mutex> lock(_callbackLock);
 					if (_pollCallback != nullptr) {
 						_pollCallback(jc->intHandle, jc->simple_state, jc->last_simple_state, jc->imu_state, jc->last_imu_state, jc->delta_time);
 					}
@@ -120,7 +120,6 @@ void pollIndividualLoop(JoyShock *jc) {
 					if (jc->controller_type != ControllerType::n_switch && _pollTouchCallback != nullptr) {
 						_pollTouchCallback(jc->intHandle, jc->touch_state, jc->last_touch_state, jc->delta_time);
 					}
-					_callbackLock.unlock_shared();
 				}
 				// count how many have no IMU result. We want to periodically attempt to enable IMU if it's not present
 				if (!hasIMU)


### PR DESCRIPTION
If the user's callback functions throw an exception, the shared read-lock will never unlock, and create a deadlock if the callbacks are attempted to be updated afterwords. This is easily solved with C++14's `std::shared_lock` wrapper that uses RAII to automatically call `unlock_shared` when it goes out of scope.