### PR TITLE
Hide DS4 debug message

### DIFF
--- a/JoyShockLibrary/JoyShock.cpp
+++ b/JoyShockLibrary/JoyShock.cpp
@@ -921,7 +921,9 @@ public:
 	}
 
 	void init_ds4_bt() {
-		printf("initialise, set colour\n");
+		#ifdef _DEBUG
+			printf("initialise, set colour\n");
+		#endif
 		unsigned char buf[78];
 		memset(buf, 0, 78);
 


### PR DESCRIPTION
Hi, this is hiding the debug messages for DualShock 4 that are displayed periodically.