### PR TITLE
Gamepad connection status & device path

### DIFF
--- a/JoyShockLibrary/JoyShockLibrary.cpp
+++ b/JoyShockLibrary/JoyShockLibrary.cpp
@@ -1005,6 +1005,8 @@ JSL_SETTINGS JslGetControllerInfoAndSettings(int deviceId)
 		settings.isConnected = true;
 		settings.isCalibrating = jc->use_continuous_calibration;
 		settings.autoCalibrationEnabled = jc->motion.GetCalibrationMode() != GamepadMotionHelpers::CalibrationMode::Manual;
+		settings.isWired = jc->is_usb;
+		settings.controllerPath = jc->path;
 
 		switch (jc->controller_type)
 		{

--- a/JoyShockLibrary/JoyShockLibrary.h
+++ b/JoyShockLibrary/JoyShockLibrary.h
@@ -1,6 +1,8 @@
 // JoyShockLibrary.h - Contains declarations of functions
 #pragma once
 
+#include <string>
+
 #if _MSC_VER // this is defined when compiling with Visual Studio
 #define JOY_SHOCK_API __declspec(dllexport) // Visual Studio needs annotating exported functions with this
 #else
@@ -134,10 +136,12 @@ typedef struct JSL_SETTINGS {
 	int colour = 0;
 	int playerNumber = 0;
 	int controllerType = 0;
+	std::string controllerPath;
 	int splitType = 0;
 	bool isCalibrating = false;
 	bool autoCalibrationEnabled = false;
 	bool isConnected = false;
+	bool isWired = false;
 } JSL_SETTINGS;
 
 extern "C" JOY_SHOCK_API int JslConnectDevices();


### PR DESCRIPTION
This adds a gamepad connection type, which may be useful in the future for battery output and other things.
The device path could also be helpful for auto-locking the gamepad in HidHide, comparing devices, synchronizing when using different libraries, and so on.